### PR TITLE
chore: allow initial compilation with using typechain

### DIFF
--- a/tasks/add-liquidity.ts
+++ b/tasks/add-liquidity.ts
@@ -1,4 +1,5 @@
 import { BENTOBOX_ADDRESS, ChainId, USDC_ADDRESS, WETH9_ADDRESS } from "@sushiswap/core-sdk";
+// @ts-ignore
 import type { BentoBoxV1, BentoBoxV1__factory, ERC20Mock, TridentRouter } from "../types";
 import { task, types } from "hardhat/config";
 

--- a/tasks/cpp-deploy.ts
+++ b/tasks/cpp-deploy.ts
@@ -1,5 +1,6 @@
 import { ChainId, WETH9_ADDRESS, USDC_ADDRESS } from "@sushiswap/core-sdk";
 import { task, types } from "hardhat/config";
+// @ts-ignore
 import { ConstantProductPoolFactory, MasterDeployer } from "../types";
 
 task("cpp-deploy", "Constant Product Pool deploy")

--- a/tasks/cpp-verify.ts
+++ b/tasks/cpp-verify.ts
@@ -1,6 +1,6 @@
 import { ChainId, USDC_ADDRESS, WETH9_ADDRESS } from "@sushiswap/core-sdk";
 import { task, types } from "hardhat/config";
-
+// @ts-ignore
 import type { MasterDeployer } from "../types";
 
 task("cpp:verify", "Constant Product Pool verify")

--- a/tasks/erc20-allowance.ts
+++ b/tasks/erc20-allowance.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import type { ERC20Mock } from "../types";
 import { task } from "hardhat/config";
 

--- a/tasks/erc20-approve.ts
+++ b/tasks/erc20-approve.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import type { ERC20Mock } from "../types";
 import { constants } from "ethers";
 import { task } from "hardhat/config";

--- a/tasks/strategy.ts
+++ b/tasks/strategy.ts
@@ -1,4 +1,5 @@
 import { BENTOBOX_ADDRESS, ChainId, WETH9_ADDRESS } from "@sushiswap/core-sdk";
+// @ts-ignore
 import type { BentoBoxV1, BentoBoxV1__factory } from "../types";
 
 import { task } from "hardhat/config";

--- a/tasks/whitelist-factory.ts
+++ b/tasks/whitelist-factory.ts
@@ -1,4 +1,5 @@
 import { BENTOBOX_ADDRESS } from "@sushiswap/core-sdk";
+// @ts-ignore
 import type { MasterDeployer } from "../types";
 import { task } from "hardhat/config";
 

--- a/tasks/whitelist-router.ts
+++ b/tasks/whitelist-router.ts
@@ -1,5 +1,5 @@
+// @ts-ignore
 import type { BentoBoxV1, BentoBoxV1__factory, TridentRouter } from "../types";
-
 import { BENTOBOX_ADDRESS } from "@sushiswap/core-sdk";
 import { task } from "hardhat/config";
 


### PR DESCRIPTION
Now you can generate the initial /types types with `npx hardhat typechain`